### PR TITLE
Adding PR workflow

### DIFF
--- a/.github/workflows/pull_request_creation.yml
+++ b/.github/workflows/pull_request_creation.yml
@@ -1,0 +1,33 @@
+name: Pull request workflow
+
+on:
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  pull-request-workflow:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version:
+        - "3.7"
+        - "3.8"
+        - "3.9"
+        - "3.10"
+        - "3.11"
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v4
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Install pip dependencies
+        run: pip install -r requirements.txt
+
+      - name: Run generate.py
+        run: python ./generate_cv.py


### PR DESCRIPTION
All great repos deserve CI pipelines. This PR adds a super basic CI pipeline that verifies the `generate_cv.py` script works for all modern python versions. This avoids inadvertent changes to the repo that break this script.

@erkanncelen It would be great to add a branch protection rule to the `main` branch that requires this workflow to succeed prior to merging being permitted.