### PR TITLE
Adding ability to have custom online profiles

### DIFF
--- a/cv_data.yaml
+++ b/cv_data.yaml
@@ -8,6 +8,13 @@ email: tom.cruise@xebia.com
 phone: +31 6 12345678
 linkedin: linkedin.com/tomcruise
 github: github.com/tomcruise
+public_profiles:
+  Twitter:
+    text: "@TomCruise"
+    url: twitter.com/TomCruise
+  Wikipedia:
+    text: Tom Cruise (actor)
+    url: en.wikipedia.org/wiki/Tom_Cruise
 
 about_me: |
   I am a professional actor and Scientologist. I don't hire stunts people, I love doing my own stunts. I have extensive cloud experience, evidence can be found in my Top Gun movies. In my free time I love spending time with my children Suri, Isabella and Connor. I also like hanging from helicopters and stuff.

--- a/functions.py
+++ b/functions.py
@@ -74,8 +74,13 @@ def write(
             c.drawString(x, y, f"{line}")
             if url is not None:
                 c.linkURL(
-                    "https://www." + text,
-                    rect=(x, y, x - 40 + stringWidth(text, font, punto + 4), y + punto),
+                    "https://www." + url,
+                    rect=(
+                        x,
+                        y,
+                        x + (0.66 * stringWidth(text, font, punto + 4)),
+                        y + punto,
+                    ),
                     relative=0,
                     thickness=0,
                 )

--- a/generate_cv.py
+++ b/generate_cv.py
@@ -434,6 +434,31 @@ def generate_cv(yaml_input: str = None, image=None):
         )
         y -= 15
 
+    if "public_profiles" in cv_data and cv_data["public_profiles"]:
+        for k, v in cv_data["public_profiles"].items():
+            y = write(
+                c,
+                x,
+                y,
+                text=f"{k}:",
+                font="bold",
+                punto=8,
+                color="light_grey",
+                spacing=0,
+            )
+            y = write(
+                c,
+                x + 40,
+                y,
+                text=v["text"],
+                font="regular",
+                punto=8,
+                color="dark_grey",
+                spacing=0,
+                url=v["url"],
+            )
+            y -= 15
+
     c.save()
 
     ## MERGE PAGES INTO ONE PDF (SAVES A PPTX COPY AS WELL)


### PR DESCRIPTION
As part of our user feedback we received a request for the ability to add custom profiles URLs to our CVs. This PR adds this feature, the new `public_profiles` key is optional and can take a list of profiles.

Note that the width of the URL box was previously calculated in a rather manual manner, this PR makes the calculation a bit more sophisticated.