### PR TITLE
fixing reportlab version to reportlab<4.0.0 in requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 black
 pyyaml
-reportlab
+reportlab<4.0.0
 streamlit
 streamlit-cropper
 pre-commit


### PR DESCRIPTION
this is due to an error building wheel for pycairo, in newer versions of reportlab on python 9.