### PR TITLE
Make download filename dynamic

### DIFF
--- a/functions.py
+++ b/functions.py
@@ -13,6 +13,26 @@ from pypdf import PdfMerger
 import sys
 import textwrap
 from tqdm import trange
+import yaml
+import re
+
+
+def generate_download_file_name(yaml_input):
+    cv_data = load_yaml(yaml_input)
+    yaml_checker(cv_data)
+    first_name = cv_data["first_name"]
+    last_name = cv_data["last_name"]
+    file_name_formatted = re.sub(" ", "-", f"{first_name}-{last_name}_CV")
+    print(file_name_formatted)
+    return file_name_formatted
+
+
+def load_yaml(yaml_input):
+    if yaml_input:
+        return yaml.safe_load(yaml_input)
+    else:
+        with open("cv_data.yaml", "r") as file:
+            return yaml.safe_load(file)
 
 
 def cleanup_files(directories: list = ["cv_pages", "cv_images"]):
@@ -281,16 +301,15 @@ def generate_pptx_from_pdf(
 
 def yaml_checker(yaml):
     """
-    This function is used to assess if the current cv page will be enough
-    to display the next experience block. If not, a new page should be created.
+    This function is used to check whether the yaml contains the required fields.
     """
 
-    assert (
-        "first_name" in yaml
-    ), "'first_name' field is missing in yaml. this is a mandatory field."
-    assert (
-        "last_name" in yaml
-    ), "'last_name' field is missing in yaml. this is a mandatory field."
+    assert yaml[
+        "first_name"
+    ], "'first_name' field is missing in yaml. this is a mandatory field."
+    assert yaml[
+        "last_name"
+    ], "'last_name' field is missing in yaml. this is a mandatory field."
     assert "role" in yaml, "'role' field is missing in yaml. this is a mandatory field."
     assert (
         "email" in yaml

--- a/generate_cv.py
+++ b/generate_cv.py
@@ -3,7 +3,6 @@ from reportlab.lib.pagesizes import landscape
 from reportlab.pdfbase import pdfmetrics
 from reportlab.pdfbase.ttfonts import TTFont
 from reportlab.pdfgen import canvas
-import yaml
 
 
 def generate_cv(yaml_input: str = None, image=None):
@@ -11,11 +10,7 @@ def generate_cv(yaml_input: str = None, image=None):
     cleanup_files(directories=["cv_pages", "cv_images"])
 
     ## LOAD YAML
-    if yaml_input:
-        cv_data = yaml.safe_load(yaml_input)
-    else:
-        with open("cv_data.yaml", "r") as file:
-            cv_data = yaml.safe_load(file)
+    cv_data = load_yaml(yaml_input)
 
     ## ASSERT MANDATORY FIELDS IN YAML
     yaml_checker(cv_data)

--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -36,11 +36,15 @@ st.button(
 
 ## DOWNLOAD BUTTONS
 with open("cv_output/cv.pdf", "rb") as file:
-    # st.download_button("Download PDF", file, file_name=f"{cv_data['first_name']}_{cv_data['first_name']}_cv.pdf")
-    st.sidebar.download_button("Download PDF", file, file_name="cv.pdf")
+    st.sidebar.download_button(
+        "Download PDF", file, file_name=f"{generate_download_file_name(yaml_text)}.pdf"
+    )
 with open("cv_output/cv.pptx", "rb") as file:
-    # st.download_button("Download PDF", file, file_name=f"{cv_data['first_name']}_{cv_data['first_name']}_cv.pdf")
-    st.sidebar.download_button("Download PPTX", file, file_name="cv.pptx")
+    st.sidebar.download_button(
+        "Download PPTX",
+        file,
+        file_name=f"{generate_download_file_name(yaml_text)}.pptx",
+    )
 
 ## PDF PREVIEW: need to convert resulting cv.pdf to images, in order to display cv preview on streamlit page
 dpi = 100


### PR DESCRIPTION
- Make the name of the PDF and PPTX files dynamic when downloading these.
- Improve the yaml validation by checking for empty values as well, for `first_name` and `last_name` keys.
- Improve doc string of yaml checker by 100%.
- Move yaml load logic into it's own function.