### PR TITLE
Tighten pip versions

### DIFF
--- a/.github/workflows/pull_request_creation.yml
+++ b/.github/workflows/pull_request_creation.yml
@@ -12,11 +12,10 @@ jobs:
       fail-fast: false
       matrix:
         python-version:
-        - "3.7"
-        - "3.8"
         - "3.9"
         - "3.10"
         - "3.11"
+        - "3.12"
 
     steps:
       - uses: actions/checkout@v3

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,10 +1,10 @@
-black
-pyyaml
+black==24.10.0
+pyyaml==6.0.2
 reportlab<4.0.0
-streamlit
-streamlit-cropper
+streamlit==1.39.0
+streamlit-cropper==0.2.2
 pre-commit
-pypdf
+pypdf<5
 PyMuPDF>=1.22.0
-python-pptx
-tqdm
+python-pptx==1.0.2
+tqdm==4.66.5


### PR DESCRIPTION
The streamlit app is currently broken:
![image](https://github.com/user-attachments/assets/32709f9b-0b1c-4983-9ee0-ceddd966db19)

This PR fixes this issue by tightening the package versions.